### PR TITLE
Prevent error when channel not exist

### DIFF
--- a/Initialize.lua
+++ b/Initialize.lua
@@ -43,6 +43,7 @@ function Elephant:OnInitialize()
 end
 
 local function SetTabButtonProperties(obj, name, typeInfo)
+  if name == nil then return end
   obj:SetNormalFontObject(GameFontNormalSmall2)
   getglobal(obj:GetName() .. "Text"):SetPoint("CENTER", obj, "CENTER", 0, 2)
   obj:SetText(string.sub(name, 0, 1))


### PR DESCRIPTION
Check if channel name is nil before initialise it. This patch prevent the error when running Elephant in WoW Classic.