### PR TITLE
Retail 11.2: replace GetLootMethod with C_PartyInfo.GetLootMethod (Classic-safe)

### DIFF
--- a/Event.lua
+++ b/Event.lua
@@ -46,6 +46,15 @@ local function GetChannelIndexFromChannelName(channel_name)
   return channel_index
 end
 
+-- Retail/Classic loot-method shim
+local function GetLootMethodCompat()
+  if C_PartyInfo and C_PartyInfo.GetLootMethod then
+    return C_PartyInfo.GetLootMethod()
+  elseif GetLootMethod then
+    return GetLootMethod()
+  end
+end
+
 --[[
 Handles messages sent by the WoW engine
 as well as the ones sent by Prat.
@@ -182,7 +191,7 @@ local function HandleMessage(prat_struct, event, ...)
       end
 
       if event == "PARTY_LOOT_METHOD_CHANGED" then
-        local method, masterloot_party, masterloot_raid = GetLootMethod()
+        local method, masterloot_party, masterloot_raid = GetLootMethodCompat()
 
         if masterloot_party or masterloot_raid then
           local player

--- a/Initialize.lua
+++ b/Initialize.lua
@@ -1,3 +1,12 @@
+-- Retail/Classic loot-method shim
+local function GetLootMethodCompat()
+  if C_PartyInfo and C_PartyInfo.GetLootMethod then
+    return C_PartyInfo.GetLootMethod()
+  elseif GetLootMethod then
+    return GetLootMethod()
+  end
+end
+
 --[[
 When addon is initialized. Registers database,
 options, initializes the main frame, Elephant
@@ -45,7 +54,7 @@ function Elephant:OnInitialize()
   -- the same loot method in case of ReloadUI()
   -- Note: in case of login, a PARTY_LOOT_METHOD_CHANGED
   -- event is triggered anyway
-  Elephant.volatileConfiguration.lootmethod = C_PartyInfo.GetLootMethod()
+  Elephant.volatileConfiguration.lootmethod = GetLootMethodCompat()
 
   -- Minimap icon
   Elephant:RegisterLDBIcon()


### PR DESCRIPTION
Retail 11.2 removed/hidden the global GetLootMethod(); Retail now uses C_PartyInfo.GetLootMethod(). This caused a load error in Elephant. This PR introduces a small compatibility shim so Retail and Classic both work.

**Changes:**

- Replace calls to GetLootMethod() with GetLootMethodCompat() in **Initialize.lua** and **Event.lua.**
- GetLootMethodCompat uses C_PartyInfo.GetLootMethod if available, otherwise falls back to GetLootMethod.